### PR TITLE
fix: libdave parity and video processing

### DIFF
--- a/davey/src/cryptor/codec_utils.rs
+++ b/davey/src/cryptor/codec_utils.rs
@@ -234,7 +234,7 @@ pub fn process_frame_h265(processor: &mut OutboundFrameProcessor, frame: &[u8]) 
       );
     } else {
       // copy the whole NAL unit
-      processor.add_encrypted_bytes(&frame[nal_unit_start_index..next_nalu_start]);
+      processor.add_unencrypted_bytes(&frame[nal_unit_start_index..next_nalu_start]);
     }
 
     nalu_index_pair = next_nalu_index_pair;

--- a/davey/src/cryptor/decryptor.rs
+++ b/davey/src/cryptor/decryptor.rs
@@ -3,7 +3,7 @@ use napi_derive::napi;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use std::{
-  cmp::max,
+  cmp::min,
   collections::{HashMap, VecDeque},
   sync::Arc,
   time::{Duration, Instant},
@@ -210,7 +210,7 @@ impl Decryptor {
       self.allow_passthrough_until = Some(
         self
           .allow_passthrough_until
-          .map(|prev_expiry| max(prev_expiry, new_expiry))
+          .map(|prev_expiry| min(prev_expiry, new_expiry))
           .unwrap_or(new_expiry),
       );
     }

--- a/davey/src/cryptor/encryptor.rs
+++ b/davey/src/cryptor/encryptor.rs
@@ -171,6 +171,15 @@ impl Encryptor {
       stats.attempts += 1;
       stats.max_attempts = stats.max_attempts.max(attempt as u32);
 
+      let size = leb128_size(truncated_nonce as u64);
+      let encrypted_frame_bytes =
+        frame_size + AES_GCM_127_TRUNCATED_TAG_BYTES + size + ranges_size + 1 + MARKER_BYTES.len();
+      if encrypted_frame_bytes > encrypted_frame.len() {
+        warn!("encryption failed, encrypted frame buffer is too small");
+        success = false;
+        break;
+      }
+
       if let Ok(tag) = encrypt_result {
         encrypted_frame[frame_size..frame_size + AES_GCM_127_TRUNCATED_TAG_BYTES]
           .copy_from_slice(&tag);
@@ -186,11 +195,9 @@ impl Encryptor {
         break;
       };
 
-      let size = leb128_size(truncated_nonce as u64);
-
       let (truncated_nonce_buffer, rest) =
         encrypted_frame[frame_size + AES_GCM_127_TRUNCATED_TAG_BYTES..].split_at_mut(size);
-      let (unencrypted_ranges_buffer, rest) = rest.split_at_mut(ranges_size as usize);
+      let (unencrypted_ranges_buffer, rest) = rest.split_at_mut(ranges_size);
       let (supplemental_bytes_buffer, rest) = rest.split_at_mut(1);
       let (marker_bytes_buffer, _) = rest.split_at_mut(MARKER_BYTES.len());
 
@@ -207,7 +214,7 @@ impl Encryptor {
         break;
       }
 
-      let supplemental_bytes_large = SUPPLEMENTAL_BYTES + size + ranges_size as usize;
+      let supplemental_bytes_large = SUPPLEMENTAL_BYTES + size + ranges_size;
       if supplemental_bytes_large > u8::MAX as usize {
         warn!("encryption failed, supplemental_bytes_large check failed");
         success = false;
@@ -222,9 +229,14 @@ impl Encryptor {
       let encrypted_frame_bytes = reconstructed_frame_size
         + AES_GCM_127_TRUNCATED_TAG_BYTES
         + size
-        + ranges_size as usize
+        + ranges_size
         + 1
         + MARKER_BYTES.len();
+      if encrypted_frame_bytes > encrypted_frame.len() {
+        warn!("encryption failed, reconstructed encrypted frame exceeds buffer");
+        success = false;
+        break;
+      }
 
       if validate_encrypted_frame(&frame_processor, &encrypted_frame[..encrypted_frame_bytes]) {
         *bytes_written = encrypted_frame_bytes;
@@ -250,8 +262,20 @@ impl Encryptor {
     success
   }
 
-  pub fn get_max_ciphertext_byte_size(_media_type: &MediaType, frame_size: usize) -> usize {
-    frame_size + SUPPLEMENTAL_BYTES + TRANSFORM_PADDING_BYTES
+  pub fn get_max_ciphertext_byte_size(codec: Codec, frame: &[u8]) -> usize {
+    let mut frame_processor = OutboundFrameProcessor::new();
+    frame_processor.process_frame(frame, codec);
+    let frame_size =
+      frame_processor.encrypted_bytes.len() + frame_processor.unencrypted_bytes.len();
+    let ranges_size = unencrypted_ranges_size(&frame_processor.unencrypted_ranges);
+
+    frame_size
+      + AES_GCM_127_TRUNCATED_TAG_BYTES
+      + leb128_size(u32::MAX as u64)
+      + ranges_size
+      + 1
+      + MARKER_BYTES.len()
+      + TRANSFORM_PADDING_BYTES
   }
 
   fn get_next_cryptor_and_nonce(&mut self) -> (Option<&AeadCipher>, u32) {

--- a/davey/src/cryptor/frame_processors.rs
+++ b/davey/src/cryptor/frame_processors.rs
@@ -19,16 +19,16 @@ pub struct Range {
 
 pub type Ranges = Vec<Range>;
 
-pub fn unencrypted_ranges_size(unencrypted_ranges: &Ranges) -> u8 {
+pub fn unencrypted_ranges_size(unencrypted_ranges: &Ranges) -> usize {
   let mut size: usize = 0;
   for range in unencrypted_ranges {
     size += leb128_size(range.offset as u64);
     size += leb128_size(range.size as u64);
   }
-  size as u8
+  size
 }
 
-pub fn serialize_unencrypted_ranges(unencrypted_ranges: &Ranges, buffer: &mut [u8]) -> u8 {
+pub fn serialize_unencrypted_ranges(unencrypted_ranges: &Ranges, buffer: &mut [u8]) -> usize {
   let mut write_at = 0;
   for range in unencrypted_ranges {
     let range_size = leb128_size(range.offset as u64) + leb128_size(range.size as u64);
@@ -39,7 +39,7 @@ pub fn serialize_unencrypted_ranges(unencrypted_ranges: &Ranges, buffer: &mut [u
     write_at += write_leb128(range.offset as u64, &mut buffer[write_at..]);
     write_at += write_leb128(range.size as u64, &mut buffer[write_at..]);
   }
-  write_at as u8
+  write_at
 }
 
 pub fn deserialize_unencrypted_ranges(
@@ -132,7 +132,7 @@ pub fn do_reconstruct(
     frame_index += size;
   }
 
-  if frame_index < other_bytes.len() {
+  if other_bytes_index < other_bytes.len() {
     // copy_other_bytes(other_bytes.size() - other_bytes_index)
     let size = other_bytes.len() - other_bytes_index;
     output[frame_index..frame_index + size]

--- a/davey/src/session.rs
+++ b/davey/src/session.rs
@@ -812,8 +812,7 @@ impl DaveSession {
     }
 
     let mut out_size: usize = 0;
-    let mut encrypted_buffer =
-      vec![0u8; Encryptor::get_max_ciphertext_byte_size(&media_type, packet.len())];
+    let mut encrypted_buffer = vec![0u8; Encryptor::get_max_ciphertext_byte_size(codec, packet)];
 
     let success = self.encryptor.encrypt(
       &media_type,


### PR DESCRIPTION
Fixes some issues I ran into while using this library to implement video-related parts of Discord's voice API.

Some refs:
- https://github.com/discord/libdave/blob/main/cpp/src/codec_utils.cpp#L239
- https://github.com/discord/libdave/blob/main/cpp/src/decryptor.cpp#L38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved H.265 video encryption to correctly handle NAL unit header protection and payload encryption.
  * Enhanced ciphertext buffer sizing calculations for improved accuracy and reliability in encryption operations.
  * Fixed boundary condition validation in encrypted frame reconstruction and passthrough deadline handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->