### PR TITLE
fix: reject malformed LEB128 values

### DIFF
--- a/davey/src/cryptor/leb128.rs
+++ b/davey/src/cryptor/leb128.rs
@@ -1,4 +1,4 @@
-// const LEB128_MAX_SIZE = 10
+const LEB128_MAX_SIZE: usize = 10;
 
 pub fn leb128_size(value: u64) -> usize {
   let mut size: usize = 0;
@@ -15,7 +15,11 @@ pub fn read_leb128(slice: &[u8]) -> Option<(u64, usize)> {
   let mut shift = 0;
   let mut size = 0;
 
-  for &byte in slice {
+  for (index, &byte) in slice.iter().take(LEB128_MAX_SIZE).enumerate() {
+    if index == LEB128_MAX_SIZE - 1 && byte > 1 {
+      return None;
+    }
+
     value |= ((byte & 0x7F) as u64) << shift;
     size += 1;
     if byte & 0x80 == 0 {
@@ -37,4 +41,35 @@ pub fn write_leb128(mut value: u64, buffer: &mut [u8]) -> usize {
   buffer[size] = value as u8;
   size += 1;
   size
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{LEB128_MAX_SIZE, read_leb128};
+
+  #[test]
+  fn reads_maximum_u64() {
+    let encoded = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01];
+
+    assert_eq!(read_leb128(&encoded), Some((u64::MAX, encoded.len())));
+  }
+
+  #[test]
+  fn rejects_unterminated_value_at_maximum_size() {
+    assert_eq!(read_leb128(&[0x80; LEB128_MAX_SIZE]), None);
+  }
+
+  #[test]
+  fn rejects_overflow_in_tenth_byte() {
+    let encoded = [0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+
+    assert_eq!(read_leb128(&encoded), None);
+  }
+
+  #[test]
+  fn rejects_value_longer_than_maximum_size() {
+    let encoded = [0x80; LEB128_MAX_SIZE + 1];
+
+    assert_eq!(read_leb128(&encoded), None);
+  }
 }


### PR DESCRIPTION
## Summary

- stop `read_leb128` after the ten bytes a `u64` can encode
- reject tenth-byte payloads larger than one instead of shifting past the integer width and panicking
- cover `u64::MAX`, unterminated, overflowing, and overlong inputs

## Why

Discord voice traffic can contain malformed or overlong LEB128 values. In debug builds, the unchecked shift panics; in downstream Songbird usage that terminates the UDP receive task and leaves voice receive wedged until restart. Returning `None` lets the existing frame-validation paths reject the packet without killing the worker.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace --locked`
- `cargo clippy -p davey --all-targets --locked -- --cap-lints warn` (only the pre-existing `clippy::for_kv_map` warning at `davey/src/session.rs:906`; this patch adds no warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized LEB128-encoded values.
  * Added validation to reject tenth-byte overflow and unterminated values exceeding the supported maximum size.
  * Preserved correct decoding for the maximum supported 64-bit value.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->